### PR TITLE
chore: adjustments to docker to include more generator context

### DIFF
--- a/picard/Dockerfile
+++ b/picard/Dockerfile
@@ -23,7 +23,7 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0.414-jammy AS build
 # arbitrary library.
 
 WORKDIR /src
-COPY . ./
+COPY ./picard ./
 RUN dotnet build MakeItSo/MakeItSo.csproj -c Release
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0.414-jammy
@@ -34,4 +34,22 @@ RUN apt-get install -y unzip
 
 WORKDIR /app
 COPY --from=build /src/MakeItSo/bin/Release/net6.0 .
+
+COPY ./*.sh ./
+COPY ./CommonResourcesConfig.json ./
+COPY ./Directory.Packages.props ./
+COPY ./tools ./tools
+COPY ./apis/GoogleApis.snk ./apis/
+
+# TODO: Move to input
+COPY ./apis/apis.json ./apis/
+COPY ./README.md ./
+COPY ./.github/renovate.json ./.github/
+
+# Needed by Google.Cloud.Tools.Common.csproj to determine GoogleApis.snk directory.
+COPY ./.gitignore ./
+
+# Needed by DirectoryLayout.cs to determine root directory.
+COPY ./LICENSE ./
+
 ENTRYPOINT ["dotnet", "MakeItSo.dll"]

--- a/picard/MakeItSo/UpdateCommand.cs
+++ b/picard/MakeItSo/UpdateCommand.cs
@@ -45,7 +45,7 @@ internal class UpdateCommand : ICommand
         {
             FileName = "/bin/bash",
             ArgumentList = { "./generateapis.sh", api.Id },
-            WorkingDirectory = _outputRoot,
+            //WorkingDirectory = _outputRoot,
             EnvironmentVariables = { { "GOOGLEAPIS_DIR", _apiRoot } }
         };
         var process = Process.Start(psi)!;

--- a/toolversions.sh
+++ b/toolversions.sh
@@ -55,6 +55,7 @@ install_nuget_package() {
   # Assume that if the directory exists, it's already installed correctly.  
   if [[ -d $output ]]; then return 0; fi
   
+  echo "Installing $output"
   (mkdir -p $output;
    cd $output;
    curl -sSL https://www.nuget.org/api/v2/package/$1/$2 --output tmp.zip;
@@ -66,14 +67,17 @@ install_nuget_package() {
 # when required. (They handle the case where the tool is already installed.)
 
 install_dotcover() {
+  echo "Installing dotcover"
   install_nuget_package JetBrains.dotCover.CommandLineTools $DOTCOVER_VERSION
 }
 
 install_reportgenerator() {
+  echo "Installing reportgenerator"
   install_nuget_package ReportGenerator $REPORTGENERATOR_VERSION
 }
 
 install_protoc() {
+  echo "Installing protoc"
   install_nuget_package Google.Protobuf.Tools $PROTOC_VERSION
   
   # Temporary fix for a broken proto in the protobuf tools package
@@ -82,6 +86,7 @@ install_protoc() {
 }
 
 install_microgenerator() {
+  echo "Installing microgenerator"
   case "$OSTYPE" in
     linux*)
       declare -r RUNTIME=linux-x64
@@ -131,6 +136,7 @@ install_microgenerator() {
 }
 
 install_grpc() {
+  echo "Installing grpc"
   install_nuget_package Grpc.Tools $GRPC_VERSION
   chmod +x $GRPC_PLUGIN
 }


### PR DESCRIPTION
# NOT INTENDED FOR MERGE

Current status shown below.

`build-dotnet.sh` is in the parent directory of google-cloud-dotnet. Its contents are:
```sh
#!/bin/bash
set -e
scriptDir="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"

docker build \
  -f "$scriptDir/google-cloud-dotnet/picard/Dockerfile" \
  ./google-cloud-dotnet \
  -t picard
```
Sibling file: `run-dotnet.sh`
```sh
#!/bin/bash
set -e
scriptDir="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"

docker run \
  -v "$scriptDir/input/dotnet:/input" \
  -v "$scriptDir/googleapis:/apis" \
  -v "$scriptDir/google-cloud-dotnet:/output" \
  picard \
  --command=update \
  --api-root=/apis \
  --api=google/storage/v2 \
  --output-root=/output
```

When running:
```
sudo ./build-dotnet.sh && sudo ./run-dotnet.sh
```

Resulting behavior is:
```
Sending build context to Docker daemon   1.11GB
Step 1/20 : FROM mcr.microsoft.com/dotnet/sdk:6.0.414-jammy AS build
 ---> cefd8fda275d
Step 2/20 : WORKDIR /src
 ---> Using cache
 ---> 0be98b133070
Step 3/20 : COPY ./picard ./
 ---> 0058f336c7d1
Step 4/20 : RUN dotnet build MakeItSo/MakeItSo.csproj -c Release
 ---> Running in 234e9c2f33bb
MSBuild version 17.3.2+561848881 for .NET
  Determining projects to restore...
  Restored /src/MakeItSo/MakeItSo.csproj (in 725 ms).
  MakeItSo -> /src/MakeItSo/bin/Release/net6.0/MakeItSo.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.46
Removing intermediate container 234e9c2f33bb
 ---> 82767ccc3718
Step 5/20 : FROM mcr.microsoft.com/dotnet/sdk:6.0.414-jammy
 ---> cefd8fda275d
Step 6/20 : RUN apt-get update
 ---> Using cache
 ---> 7a164c5daa1a
Step 7/20 : RUN apt-get install -y unzip
 ---> Using cache
 ---> 3e2316299d7c
Step 8/20 : WORKDIR /app
 ---> Using cache
 ---> fdfbab62bdce
Step 9/20 : COPY --from=build /src/MakeItSo/bin/Release/net6.0 .
 ---> Using cache
 ---> 55f26c631993
Step 10/20 : COPY ./*.sh ./
 ---> Using cache
 ---> 05f1d3c405c4
Step 11/20 : COPY ./CommonResourcesConfig.json ./
 ---> Using cache
 ---> 2e5a51f2358a
Step 12/20 : COPY ./Directory.Packages.props ./
 ---> Using cache
 ---> f1ef1c7282a7
Step 13/20 : COPY ./tools ./tools
 ---> Using cache
 ---> 5ed69cb94304
Step 14/20 : COPY ./apis/GoogleApis.snk ./apis/
 ---> Using cache
 ---> b32394f4cbc7
Step 15/20 : COPY ./apis/apis.json ./apis/
 ---> Using cache
 ---> 042b26d9a4f8
Step 16/20 : COPY ./README.md ./
 ---> Using cache
 ---> 44e0c40071da
Step 17/20 : COPY ./.github/renovate.json ./.github/
 ---> c88d3c91df6a
Step 18/20 : COPY ./.gitignore ./
 ---> 1f3db789a46e
Step 19/20 : COPY ./LICENSE ./
 ---> 026ddd1fb41c
Step 20/20 : ENTRYPOINT ["dotnet", "MakeItSo.dll"]
 ---> Running in eb809c2d46b1
Removing intermediate container eb809c2d46b1
 ---> f3fc035259f1
Successfully built f3fc035259f1
Successfully tagged picard:latest
Preparing tools
Installing protoc
Installing /app/packages/Google.Protobuf.Tools.3.25.2
Installing microgenerator
Installing grpc
Installing /app/packages/Grpc.Tools.2.60.0
/root/.nuget/packages/microsoft.build.tasks.git/8.0.0/build/Microsoft.Build.Tasks.Git.targets(25,5): warning : Unable to locate repository with working directory that contains directory '/app/tools/Google.Cloud.Tools.VersionCompat'. [/app/tools/Google.Cloud.Tools.VersionCompat/Google.Cloud.Tools.VersionCompat.csproj]
/root/.nuget/packages/microsoft.build.tasks.git/8.0.0/build/Microsoft.Build.Tasks.Git.targets(25,5): warning : Unable to locate repository with working directory that contains directory '/app/tools/Google.Cloud.Tools.ApiIndex.V1'. [/app/tools/Google.Cloud.Tools.ApiIndex.V1/Google.Cloud.Tools.ApiIndex.V1.csproj]
/root/.nuget/packages/microsoft.sourcelink.common/8.0.0/build/Microsoft.SourceLink.Common.targets(53,5): warning : Source control information is not available - the generated source link is empty. [/app/tools/Google.Cloud.Tools.VersionCompat/Google.Cloud.Tools.VersionCompat.csproj]
/root/.nuget/packages/microsoft.sourcelink.common/8.0.0/build/Microsoft.SourceLink.Common.targets(53,5): warning : Source control information is not available - the generated source link is empty. [/app/tools/Google.Cloud.Tools.ApiIndex.V1/Google.Cloud.Tools.ApiIndex.V1.csproj]
/root/.nuget/packages/microsoft.build.tasks.git/8.0.0/build/Microsoft.Build.Tasks.Git.targets(25,5): warning : Unable to locate repository with working directory that contains directory '/app/tools/Google.Cloud.Tools.Common'. [/app/tools/Google.Cloud.Tools.Common/Google.Cloud.Tools.Common.csproj]
/root/.nuget/packages/microsoft.sourcelink.common/8.0.0/build/Microsoft.SourceLink.Common.targets(53,5): warning : Source control information is not available - the generated source link is empty. [/app/tools/Google.Cloud.Tools.Common/Google.Cloud.Tools.Common.csproj]
/root/.nuget/packages/microsoft.build.tasks.git/8.0.0/build/Microsoft.Build.Tasks.Git.targets(25,5): warning : Unable to locate repository with working directory that contains directory '/app/tools/Google.Cloud.Tools.ReleaseManager'. [/app/tools/Google.Cloud.Tools.ReleaseManager/Google.Cloud.Tools.ReleaseManager.csproj]
/root/.nuget/packages/microsoft.sourcelink.common/8.0.0/build/Microsoft.SourceLink.Common.targets(53,5): warning : Source control information is not available - the generated source link is empty. [/app/tools/Google.Cloud.Tools.ReleaseManager/Google.Cloud.Tools.ReleaseManager.csproj]
2024-11-22T20:43:56.022Z Generating Google.Cloud.Storage.V2
Regenerating projects
API catalog contains 283 entries
Failed: System.IO.DirectoryNotFoundException: Could not find a part of the path '/app/apis/Google.Ads.AdManager.V1'.
   at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
   at System.IO.Enumeration.FileSystemEnumerator`1.Init()
   at System.IO.Enumeration.FileSystemEnumerator`1..ctor(String directory, Boolean isNormalized, EnumerationOptions options)
   at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
   at System.IO.Enumeration.FileSystemEnumerableFactory.UserDirectories(String directory, String expression, EnumerationOptions options)
   at System.IO.Directory.InternalEnumeratePaths(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
   at System.IO.Directory.GetDirectories(String path, String searchPattern, EnumerationOptions enumerationOptions)
   at System.IO.Directory.GetDirectories(String path)
   at Google.Cloud.Tools.ReleaseManager.GenerateProjectsCommand.GenerateProjects(String apiRoot, ApiMetadata api, HashSet`1 apiNames) in /app/tools/Google.Cloud.Tools.ReleaseManager/GenerateProjectsCommand.cs:line 387
   at Google.Cloud.Tools.ReleaseManager.GenerateProjectsCommand.ExecuteImpl(String[] args) in /app/tools/Google.Cloud.Tools.ReleaseManager/GenerateProjectsCommand.cs:line 170
   at Google.Cloud.Tools.ReleaseManager.CommandBase.Execute(String[] args) in /app/tools/Google.Cloud.Tools.ReleaseManager/CommandBase.cs:line 62
   at Google.Cloud.Tools.ReleaseManager.GenerateApisCommand.Execute(String[] args) in /app/tools/Google.Cloud.Tools.ReleaseManager/GenerateApisCommand.cs:line 95
   at Google.Cloud.Tools.ReleaseManager.Program.Main(String[] args) in /app/tools/Google.Cloud.Tools.ReleaseManager/Program.cs:line 39
Error executing command: System.Exception: Generation ended with exit code 1
   at MakeItSo.UpdateCommand.Execute() in /src/MakeItSo/UpdateCommand.cs:line 55
   at Program.<Main>$(String[] args) in /src/MakeItSo/Program.cs:line 75
```